### PR TITLE
Make Boxen's Homebrew-installed Node + Tower play nicely together

### DIFF
--- a/hook
+++ b/hook
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-PATH="/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+PATH="/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/boxen/homebrew/bin:$PATH"
 node $(dirname $0)/pre-commit.js


### PR DESCRIPTION
### What does this PR do? How does it affect users?

(dev tools change only)

This adds Boxen's Homebrew binaries folder to the path the pre-commit script looks for Node in. This is necessary to for Tower X Boxen X Homebrew X Node combo to work...
